### PR TITLE
submodule awesome-python.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "awesome-python"]
+	path = awesome-python
+	url = https://github.com/vinta/awesome-python.git

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Curated list of Python resources (guides, tutorials, books, etc)
 - [Web Frameworks]
 - [Hosting]
 
+## See also
+We only scratch the common choices here. If you are looking to explore the other
+myriad possible choices, take a look at the [awesome-python](https://github.com/vinta/awesome-python)
+listing.
+
 ## Contributing
 This repo is maintained by PythonPH. If you find any mistakes, wish to contribute your changes or submit suggestions, you may:
 1. fork this repo to your own github account and submit a pull request or 


### PR DESCRIPTION
I just saw the link announcement at the FB group. Wowsome idea. This is a good way of dealing with repeated questions (and, side-effect, gettting PythonPH peeps exposed to git even in a small way).

I find two problems tho:
1. The "curated list" idea is already done in [awesome-python](https://github.com/vinta/awesome-python). At 678 commits and 10,609 forks as of press time, that list will be way more comprehensive and updated than ours.
2. OTOH, the sheer size of the awesome-python list makes it daunting for beginners to search/read-up. They will just end up posting questions at the Facebook group again! :|

Solution: Leave the listing to awesome-python, answer sticky PythonPH queries in this repo[1].

So, I submoduled awesome-python so pylinks will always have a pointer to the comprehensive list. I also added a note pointing to awesome-python in the README.

[1] Next step of course would be to answer the queries in the issues. Man, this is really good use of Github.

^_^
