### PR TITLE
add links to official tutorial from Python.org

### DIFF
--- a/basic-python.md
+++ b/basic-python.md
@@ -1,4 +1,7 @@
 ## Beginner-friendly Python Resources
+- The Python Tutorial (from Python.org)
+  - [For Python 2.x](https://docs.python.org/2/tutorial/index.html)
+  - [For Python 3.x](https://docs.python.org/3/tutorial/index.html)
 - [Learn Python the Hard Way by Zed Shaw](http://learnpythonthehardway.org/book/)
 - [Google Python Class](https://developers.google.com/edu/python/)
 - [Python for Informatics](http://pythonlearn.com/book.php)

--- a/text-editors-ides.md
+++ b/text-editors-ides.md
@@ -1,5 +1,9 @@
 ## Text Editors
+- [Scite](http://www.scintilla.org/SciTE.html)
 - [SublimeText](http://www.sublimetext.com/)
 
 ## IDEs
+- [Eric IDE](http://eric-ide.python-projects.org/)
 - [PyCharm](https://www.jetbrains.com/pycharm/)
+- [PyDev](http://pydev.org/)
+- [Wingware](https://wingware.com/)

--- a/web-frameworks.md
+++ b/web-frameworks.md
@@ -1,6 +1,11 @@
 ## Web Frameworks
+- [Bottle](http://bottlepy.org/docs/dev/index.html)
 - [Django](https://www.djangoproject.com/)
+- [Falcon](https://falconframework.org/)
 - [Flask](http://flask.pocoo.org/)
+- [Pyramid/Pylons](http://www.pylonsproject.org/)
+- [Web2Py](http://www.web2py.com/)
+
 
 ## Relevant libraries
 - [SQL Alchemy](http://www.sqlalchemy.org/) - For Object-Relational Mapping.


### PR DESCRIPTION
I've always wondered why the official Python.org tutorials aren't here, hence this PR ;)

EDIT: more links, too :)
